### PR TITLE
improve(sec): add specific tasks configuration for SEC crew

### DIFF
--- a/finmas/crews/sec/config/tasks.yaml
+++ b/finmas/crews/sec/config/tasks.yaml
@@ -1,21 +1,33 @@
 sec_filing_analysis_task:
   description: >
-    Create an analysis report for the SEC filings (10-K or 10-Q) for the company {ticker}.
+    Analyze the {form} SEC filing for the stock ticker {ticker} by using your assigned tool. Extract information
+    about the growth in key market segments, and key developments. Focus on key sections like Management's Discussion and analysis
+    and Risk Factors. Include information about any key products and forward-looking statements from management.
+
   expected_output: >
-    A report that includes key financial metrics, risks, and operational updates based on the latest SEC filings.
+    The final answer should be a report that includes information about market segments, management discussion,
+    risk factors and key developments.
+
   agent: sec_filing_analyzer
 
 sec_filing_sentiment_task:
   description: >
-    Create a sentiment analysis report for the company's SEC filings (10-K or 10-Q).
+    Create a sentiment analysis report for the stock ticker {ticker} {form} SEC filing from the management discussion and analysis section.
+    Only use your assigned tool.
+
   expected_output: >
-    A sentiment analysis report that highlights the tone and sentiment expressed in the management discussion and analysis section.
+    A sentiment analysis report that highlights the tone and sentiment from the extracted text.
+    Include a couple of examples of sentence to illustrate the sentiment.
+
   agent: sec_filing_sentiment_analyzer
 
 sec_filing_summary_task:
   description: >
-    Create a summary report for the company's SEC filings (10-K or 10-Q).
-    Include key financial insights, sentiment, and operational highlights.
+    Create a summary report for the stock ticker {ticker} {form} SEC filing.
+    Include key insights extracted from the SEC filing with key market segments, key developments and information
+    from Management's Discussion and analysis.
+
   expected_output: >
-    A concise summary report that provides key financial metrics, major updates, and an overall assessment.
+    A concise summary report that provides key information and sentiment analysis from the SEC filing.
+
   agent: sec_filing_summarizer


### PR DESCRIPTION
Take a look at this tasks configuration. I did not get so great results with it, but I think it was a step in the right direction.

I copy in a draft I have for the docs:

Fundamental data like income statement and balance sheets are already available in
structured format from various providers. So the goal of analyzing an SEC filing
is more focused on extracting key insights from the unstructured text and comments
from the SEC filing. The 10-Q and 10-K filings can be around 500 pages for some companies.
As a Financial Analyst it is time consuming to manually go through or read several filings.
Therefore an focused AI agent could extract key insights from these filings to
help the analyst get an overview over the latest declared info from the company.

Relevant information that can be extracted from these reports can be:

- Reporting on different market segments. Which segments are growing and which are declining?
- Forward looking statements from management. What are some of the anticipatied challenges and priorities going forward?
- What are some of the unique risks from the company?